### PR TITLE
fix: delete kovan network

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,4 @@ repos:
 
 
 default_language_version:
-    python: python3.8
+    python: python3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ cd ape-optimism
 python3 -m venv venv
 source venv/bin/activate
 
-# install brownie into the virtual environment
+# install ape-optimism into the virtual environment
 python setup.py install
 
 # install the developer dependencies (-e is interactive mode)

--- a/ape_optimism/__init__.py
+++ b/ape_optimism/__init__.py
@@ -21,10 +21,10 @@ def ecosystems():
 def networks():
     for network_name, network_params in NETWORKS.items():
         yield "optimism", network_name, create_network_type(*network_params)
+        yield "optimism", f"{network_name}-fork", NetworkAPI
 
-    # NOTE: This works for development providers, as they get chain_id from themselves
+    # NOTE: This works for local providers, as they get chain_id from themselves
     yield "optimism", LOCAL_NETWORK_NAME, NetworkAPI
-    yield "optimism", "mainnet-fork", NetworkAPI
 
 
 @plugins.register(plugins.ProviderPlugin)

--- a/ape_optimism/ecosystem.py
+++ b/ape_optimism/ecosystem.py
@@ -1,6 +1,9 @@
+from typing import Optional, Type, Union, cast
+
 from ape.api import TransactionAPI
 from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
+from ape.exceptions import ApeException
 from ape.types import TransactionSignature
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 from ape_ethereum.transactions import StaticFeeTransaction, TransactionType
@@ -10,55 +13,52 @@ from eth_utils import add_0x_prefix, decode_hex
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (10, 10),
-    "kovan": (69, 69),
     "goerli": (420, 420),
 }
 
 
+class ApeOptimismError(ApeException):
+    """
+    Raised in the ape-optimism plugin.
+    """
+
+
+def _create_network_config(
+    required_confirmations: int = 1, block_time: int = 2, **kwargs
+) -> NetworkConfig:
+    return NetworkConfig(
+        required_confirmations=required_confirmations, block_time=block_time, **kwargs
+    )  # type: ignore
+
+
 class OptimismConfig(PluginConfig):
-    mainnet: NetworkConfig = NetworkConfig(required_confirmations=1, block_time=2)  # type: ignore
-    kovan: NetworkConfig = NetworkConfig(required_confirmations=1, block_time=2)  # type: ignore
-    goerli: NetworkConfig = NetworkConfig(required_confirmations=1, block_time=2)  # type: ignore
-    local: NetworkConfig = NetworkConfig(default_provider="test")  # type: ignore
+    mainnet: NetworkConfig = _create_network_config()
+    goerli: NetworkConfig = _create_network_config()
+    local: NetworkConfig = _create_network_config(
+        required_confirmations=0, default_provider="test", block_time=0
+    )
     default_network: str = LOCAL_NETWORK_NAME
 
 
 class Optimism(Ethereum):
     @property
     def config(self) -> OptimismConfig:  # type: ignore
-        return self.config_manager.get_config("optimism")  # type: ignore
+        return cast(OptimismConfig, self.config_manager.get_config("optimism"))
 
     def create_transaction(self, **kwargs) -> TransactionAPI:
         """
         Returns a transaction using the given constructor kwargs.
+        Overridden because does not support
+
+        **kwargs: Kwargs for the transaction class.
+
         Returns:
             :class:`~ape.api.transactions.TransactionAPI`
         """
 
-        transaction_types = {
-            TransactionType.STATIC: StaticFeeTransaction,
-        }
-
-        if "type" in kwargs:
-            type_kwarg = kwargs["type"]
-            if type_kwarg is None:
-                type_kwarg = TransactionType.STATIC.value
-            elif isinstance(type_kwarg, int):
-                type_kwarg = f"0{type_kwarg}"
-            elif isinstance(type_kwarg, bytes):
-                type_kwarg = type_kwarg.hex()
-
-            suffix = type_kwarg.replace("0x", "")
-            if len(suffix) == 1:
-                type_kwarg = f"{type_kwarg.rstrip(suffix)}0{suffix}"
-
-            version_str = add_0x_prefix(HexStr(type_kwarg))
-            version = TransactionType(version_str)
-        else:
-            version = TransactionType.STATIC
-
-        txn_class = transaction_types[version]
-        kwargs["type"] = version.value
+        transaction_type = _get_transaction_type(kwargs.get("type"))
+        kwargs["type"] = transaction_type.value
+        txn_class = _get_transaction_cls(transaction_type)
 
         if "required_confirmations" not in kwargs or kwargs["required_confirmations"] is None:
             # Attempt to use default required-confirmations from `ape-config.yaml`.
@@ -82,4 +82,32 @@ class Optimism(Ethereum):
                 s=bytes(kwargs["s"]),
             )
 
-        return txn_class(**kwargs)  # type: ignore
+        return txn_class.parse_obj(kwargs)
+
+
+def _get_transaction_type(_type: Optional[Union[int, str, bytes]]) -> TransactionType:
+    if not _type:
+        return TransactionType.STATIC
+
+    if _type is None:
+        _type = TransactionType.STATIC.value
+    elif isinstance(_type, int):
+        _type = f"0{_type}"
+    elif isinstance(_type, bytes):
+        _type = _type.hex()
+
+    suffix = _type.replace("0x", "")
+    if len(suffix) == 1:
+        _type = f"{_type.rstrip(suffix)}0{suffix}"
+
+    return TransactionType(add_0x_prefix(HexStr(_type)))
+
+
+def _get_transaction_cls(transaction_type: TransactionType) -> Type[TransactionAPI]:
+    transaction_types = {
+        TransactionType.STATIC: StaticFeeTransaction,
+    }
+    if transaction_type not in transaction_types:
+        raise ApeOptimismError(f"Transaction type '{transaction_type}' not supported.")
+
+    return transaction_types[transaction_type]

--- a/ape_optimism/ecosystem.py
+++ b/ape_optimism/ecosystem.py
@@ -31,12 +31,18 @@ def _create_network_config(
     )  # type: ignore
 
 
+def _create_local_config(default_provider: Optional[str] = None) -> NetworkConfig:
+    return _create_network_config(
+        required_confirmations=0, block_time=0, default_provider=default_provider
+    )
+
+
 class OptimismConfig(PluginConfig):
     mainnet: NetworkConfig = _create_network_config()
+    mainnet_fork: NetworkConfig = _create_local_config()
     goerli: NetworkConfig = _create_network_config()
-    local: NetworkConfig = _create_network_config(
-        required_confirmations=0, default_provider="test", block_time=0
-    )
+    goerli_fork: NetworkConfig = _create_local_config()
+    local: NetworkConfig = _create_local_config(default_provider="test")
     default_network: str = LOCAL_NETWORK_NAME
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     url="https://github.com/ApeWorX/ape-optimism",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.5.0,<0.6.0",
+        "eth-ape>=0.5.2,<0.6.0",
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

The optimism Kovan network is deprecated and gone from existance.
This PR removes its support from the plugin.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
