### PR TITLE
fix: issues with type 2 transactions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,18 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.12.0
+    rev: 23.12.1
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.8.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]

--- a/ape_optimism/ecosystem.py
+++ b/ape_optimism/ecosystem.py
@@ -1,18 +1,11 @@
-from typing import Dict, Optional, Type, cast
+from typing import Optional, Type, cast
 
-from ape.api import TransactionAPI
 from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.exceptions import ApeException
-from ape.types import TransactionSignature
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 from ape_ethereum.ecosystem import Ethereum, ForkedNetworkConfig, NetworkConfig
-from ape_ethereum.transactions import (
-    AccessListTransaction,
-    DynamicFeeTransaction,
-    StaticFeeTransaction,
-    TransactionType,
-)
+from ape_ethereum.transactions import TransactionType
 
 NETWORKS = {
     # chain_id, network_id
@@ -34,7 +27,7 @@ def _create_config(
     return cls(
         required_confirmations=required_confirmations,
         block_time=block_time,
-        default_transaction_type=TransactionType.STATIC,
+        default_transaction_type=TransactionType.DYNAMIC,
         **kwargs,
     )
 
@@ -66,74 +59,3 @@ class Optimism(Ethereum):
     @property
     def config(self) -> OptimismConfig:  # type: ignore
         return cast(OptimismConfig, self.config_manager.get_config("optimism"))
-
-    def create_transaction(self, **kwargs) -> TransactionAPI:
-        """
-        Returns a transaction using the given constructor kwargs.
-        Overridden because does not support
-
-        **kwargs: Kwargs for the transaction class.
-
-        Returns:
-            :class:`~ape.api.transactions.TransactionAPI`
-        """
-
-        transaction_types: Dict[int, Type[TransactionAPI]] = {
-            TransactionType.STATIC.value: StaticFeeTransaction,
-            TransactionType.DYNAMIC.value: DynamicFeeTransaction,
-            TransactionType.ACCESS_LIST.value: AccessListTransaction,
-        }
-
-        if "type" in kwargs:
-            if kwargs["type"] is None:
-                # The Default is pre-EIP-1559.
-                version = self.default_transaction_type.value
-            elif not isinstance(kwargs["type"], int):
-                version = self.conversion_manager.convert(kwargs["type"], int)
-            else:
-                version = kwargs["type"]
-
-        elif "gas_price" in kwargs:
-            version = TransactionType.STATIC.value
-        else:
-            version = self.default_transaction_type.value
-
-        kwargs["type"] = version
-        txn_class = transaction_types[version]
-
-        if "required_confirmations" not in kwargs or kwargs["required_confirmations"] is None:
-            # Attempt to use default required-confirmations from `ape-config.yaml`.
-            required_confirmations = 0
-            active_provider = self.network_manager.active_provider
-            if active_provider:
-                required_confirmations = active_provider.network.required_confirmations
-
-            kwargs["required_confirmations"] = required_confirmations
-
-        if isinstance(kwargs.get("chainId"), str):
-            kwargs["chainId"] = int(kwargs["chainId"], 16)
-
-        elif "chainId" not in kwargs and self.network_manager.active_provider is not None:
-            kwargs["chainId"] = self.provider.chain_id
-
-        if "input" in kwargs:
-            kwargs["data"] = kwargs.pop("input")
-
-        if all(field in kwargs for field in ("v", "r", "s")):
-            kwargs["signature"] = TransactionSignature(
-                v=kwargs["v"],
-                r=bytes(kwargs["r"]),
-                s=bytes(kwargs["s"]),
-            )
-
-        if "max_priority_fee_per_gas" in kwargs:
-            kwargs["max_priority_fee"] = kwargs.pop("max_priority_fee_per_gas")
-        if "max_fee_per_gas" in kwargs:
-            kwargs["max_fee"] = kwargs.pop("max_fee_per_gas")
-
-        kwargs["gas"] = kwargs.pop("gas_limit", kwargs.get("gas"))
-
-        if "value" in kwargs and not isinstance(kwargs["value"], int):
-            kwargs["value"] = self.conversion_manager.convert(kwargs["value"], int)
-
-        return txn_class(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=23.12.0,<24",  # Auto-formatter and linter
-        "mypy>=1.7.1,<2",  # Static type analyzer
+        "black>=23.12.1,<24",  # Auto-formatter and linter
+        "mypy>=1.8.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
-        "flake8>=6.1.0,<7",  # Style linter
+        "flake8>=7.0.0,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
         "isort>=5.10.1,<6",  # Import sorting linter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def optimism(networks):
     return networks.optimism
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def eth_tester_provider():
     if not ape.networks.active_provider or ape.networks.provider.name != "test":
         with ape.networks.optimism.local.use_provider("test") as provider:

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -9,9 +9,15 @@ def test_gas_limit(optimism):
 
 # NOTE: None because we want to show the default is STATIC
 @pytest.mark.parametrize("tx_type", (None, 0, "0x0"))
-def test_create_transaction(optimism, tx_type, eth_tester_provider):
+def test_create_transaction_type_0(optimism, tx_type):
     txn = optimism.create_transaction(type=tx_type)
     assert txn.type == TransactionType.STATIC.value
+
+
+@pytest.mark.parametrize("tx_type", (2, "0x02"))
+def test_create_transaction_type_0(optimism, tx_type):
+    txn = optimism.create_transaction(type=tx_type)
+    assert txn.type == TransactionType.DYNAMIC.value
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -7,16 +7,38 @@ def test_gas_limit(optimism):
     assert optimism.config.local.gas_limit == "max"
 
 
-# NOTE: None because we want to show the default is STATIC
-@pytest.mark.parametrize("tx_type", (None, 0, "0x0"))
-def test_create_transaction_type_0(optimism, tx_type):
-    txn = optimism.create_transaction(type=tx_type)
+@pytest.mark.parametrize(
+    "tx_kwargs",
+    [
+        {"type": 0},
+        {"gas_price": 0},
+        {"gasPrice": 0},
+    ],
+)
+def test_create_transaction_type_0(optimism, tx_kwargs):
+    txn = optimism.create_transaction(**tx_kwargs)
     assert txn.type == TransactionType.STATIC.value
 
 
-@pytest.mark.parametrize("tx_type", (2, "0x02"))
-def test_create_transaction_type_0(optimism, tx_type):
-    txn = optimism.create_transaction(type=tx_type)
+@pytest.mark.parametrize(
+    "tx_kwargs",
+    [
+        {},  # Default is type 2 in Optimism.
+        {"type": 2},
+        {"max_fee": 0},
+        {"max_fee_per_gas": 0},
+        {"maxFee": 0},
+        {"max_priority_fee_per_gas": 0},
+        {"max_priority_fee": 0},
+        {"maxPriorityFeePerGas": 0},
+    ],
+)
+def test_create_transaction_type_2(optimism, tx_kwargs):
+    """
+    Show is smart-enough to deduce type 2 transactions.
+    """
+
+    txn = optimism.create_transaction(**tx_kwargs)
     assert txn.type == TransactionType.DYNAMIC.value
 
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -5,6 +5,4 @@ def test_use_provider(accounts, networks):
 
         assert not receipt.failed
         assert receipt.value == 100
-
-        # Transactions in Optimism are always static-fee type (0).
-        assert receipt.type == 0
+        assert receipt.type == 2


### PR DESCRIPTION
### What I did

Optimism was particularly bad at creating type 2 transactions.
It wasnt smart enough like Ethereum to create the correct tx.
Also - EIP-1559 is supported in Optimism networks now since bedrock so changed the default there.

fixes: https://github.com/ApeWorX/ape/issues/1865

### How I did it

delete overriden method

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
