### PR TITLE
fix: issue where could not decode blocks containing system transactions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 24.2.0
     hooks:
       - id: black
         name: black

--- a/ape_optimism/ecosystem.py
+++ b/ape_optimism/ecosystem.py
@@ -8,7 +8,7 @@ from ape_ethereum.ecosystem import (
     NetworkConfig,
     create_network_config,
 )
-from hexbytes import HexBytes
+from eth_pydantic_types import HexBytes
 
 NETWORKS = {
     # chain_id, network_id

--- a/ape_optimism/ecosystem.py
+++ b/ape_optimism/ecosystem.py
@@ -1,12 +1,14 @@
 from typing import cast
 
-from ape.exceptions import ApeException
+from ape.api import TransactionAPI
+from ape.exceptions import ApeException, APINotImplementedError
 from ape_ethereum.ecosystem import (
     BaseEthereumConfig,
     Ethereum,
     NetworkConfig,
     create_network_config,
 )
+from hexbytes import HexBytes
 
 NETWORKS = {
     # chain_id, network_id
@@ -14,6 +16,7 @@ NETWORKS = {
     "goerli": (420, 420),
     "sepolia": (11155420, 11155420),
 }
+SYSTEM_TRANSACTION = 126
 
 
 class ApeOptimismError(ApeException):
@@ -29,7 +32,24 @@ class OptimismConfig(BaseEthereumConfig):
     sepolia: NetworkConfig = create_network_config(block_time=2)
 
 
+class SystemTransaction(TransactionAPI):
+    type: int = SYSTEM_TRANSACTION
+
+    @property
+    def txn_hash(self) -> HexBytes:
+        raise APINotImplementedError("Unable to calculate the hash of system transactions.")
+
+    def serialize_transaction(self) -> bytes:
+        raise APINotImplementedError("Unable to serialize system transactions.")
+
+
 class Optimism(Ethereum):
     @property
     def config(self) -> OptimismConfig:  # type: ignore
         return cast(OptimismConfig, self.config_manager.get_config("optimism"))
+
+    def create_transaction(self, **kwargs) -> TransactionAPI:
+        if kwargs.get("type") == SYSTEM_TRANSACTION:
+            return SystemTransaction.model_validate(kwargs)
+
+        return super().create_transaction(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=23.12.1,<24",  # Auto-formatter and linter
+        "black>=24.2.0,<25",  # Auto-formatter and linter
         "mypy>=1.8.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
         "flake8>=7.0.0,<8",  # Style linter

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -2,6 +2,8 @@ import pytest
 from ape_ethereum.transactions import TransactionType
 from ethpm_types.abi import MethodABI
 
+from ape_optimism.ecosystem import SYSTEM_TRANSACTION, SystemTransaction
+
 
 def test_gas_limit(optimism):
     assert optimism.config.local.gas_limit == "max"
@@ -40,6 +42,23 @@ def test_create_transaction_type_2(optimism, tx_kwargs):
 
     txn = optimism.create_transaction(**tx_kwargs)
     assert txn.type == TransactionType.DYNAMIC.value
+
+
+def test_create_transaction_type_126(optimism):
+    data = {
+        "chainId": 0,
+        "to": "0x4200000000000000000000000000000000000015",
+        "from": "0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001",
+        "gas": 1000000,
+        "nonce": 11021459,
+        "value": 0,
+        "data": "0x",
+        "type": 126,
+        "accessList": [],
+    }
+    actual = optimism.create_transaction(**data)
+    assert isinstance(actual, SystemTransaction)
+    assert actual.type == SYSTEM_TRANSACTION
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What I did

We can now "create" system transactions, which happens during the decoding of blocks.

### How I did it

add new tx with this type and short-circuit decode to this type instead of the other types.

### How to verify it

```python
chain.block.head
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
