### PR TITLE
refactor: remove goerli

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ python3 setup.py install
 Installing this plugin adds support for the Optimism ecosystem:
 
 ```bash
-ape console --network optimism:goerli
+ape console --network optimism:sepolia
 ```
 
 ## Development

--- a/ape_optimism/ecosystem.py
+++ b/ape_optimism/ecosystem.py
@@ -13,7 +13,6 @@ from eth_pydantic_types import HexBytes
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (10, 10),
-    "goerli": (420, 420),
     "sepolia": (11155420, 11155420),
 }
 SYSTEM_TRANSACTION = 126
@@ -28,7 +27,6 @@ class ApeOptimismError(ApeException):
 # NOTE: Forked networks automatically are included.
 class OptimismConfig(BaseEthereumConfig):
     mainnet: NetworkConfig = create_network_config(block_time=2)
-    goerli: NetworkConfig = create_network_config(block_time=2)
     sepolia: NetworkConfig = create_network_config(block_time=2)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,8 +6,6 @@ EXPECTED_OUTPUT = """
 optimism
 ├── mainnet
 │   └── geth  (default)
-├── goerli
-│   └── geth  (default)
 ├── sepolia
 │   └── geth  (default)
 └── local  (default)
@@ -48,7 +46,6 @@ def assert_rich_text(actual: str, expected: str):
 
 def test_networks(runner, cli, optimism):
     optimism.mainnet.set_default_provider("geth")
-    optimism.goerli.set_default_provider("geth")
     optimism.sepolia.set_default_provider("geth")
 
     result = runner.invoke(cli, ["networks", "list"])


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
