### PR TITLE
perf: plugin load time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,33 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
 
 -   repo: https://github.com/PyCQA/isort
-    rev: v5.13.2
+    rev: 5.13.2
     hooks:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.10.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.13.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 0.7.18
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter]

--- a/ape_optimism/__init__.py
+++ b/ape_optimism/__init__.py
@@ -1,23 +1,31 @@
 from ape import plugins
-from ape.api.networks import LOCAL_NETWORK_NAME, ForkedNetworkAPI, NetworkAPI, create_network_type
-from ape_node import Node
-from ape_test import LocalProvider
-
-from .ecosystem import NETWORKS, Optimism, OptimismConfig
 
 
 @plugins.register(plugins.Config)
 def config_class():
+    from ape_optimism.ecosystem import OptimismConfig
+
     return OptimismConfig
 
 
 @plugins.register(plugins.EcosystemPlugin)
 def ecosystems():
+    from ape_optimism.ecosystem import Optimism
+
     yield Optimism
 
 
 @plugins.register(plugins.NetworkPlugin)
 def networks():
+    from ape.api.networks import (
+        LOCAL_NETWORK_NAME,
+        ForkedNetworkAPI,
+        NetworkAPI,
+        create_network_type,
+    )
+
+    from ape_optimism.ecosystem import NETWORKS
+
     for network_name, network_params in NETWORKS.items():
         yield "optimism", network_name, create_network_type(*network_params)
         yield "optimism", f"{network_name}-fork", ForkedNetworkAPI
@@ -28,6 +36,12 @@ def networks():
 
 @plugins.register(plugins.ProviderPlugin)
 def providers():
+    from ape.api.networks import LOCAL_NETWORK_NAME
+    from ape_node import Node
+    from ape_test import LocalProvider
+
+    from ape_optimism.ecosystem import NETWORKS
+
     for network_name in NETWORKS:
         yield "optimism", network_name, Node
 

--- a/ape_optimism/ecosystem.py
+++ b/ape_optimism/ecosystem.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from ape.api import TransactionAPI
 from ape.exceptions import ApeException, APINotImplementedError
@@ -8,7 +8,9 @@ from ape_ethereum.ecosystem import (
     NetworkConfig,
     create_network_config,
 )
-from eth_pydantic_types import HexBytes
+
+if TYPE_CHECKING:
+    from eth_pydantic_types import HexBytes
 
 NETWORKS = {
     # chain_id, network_id
@@ -34,7 +36,7 @@ class SystemTransaction(TransactionAPI):
     type: int = SYSTEM_TRANSACTION
 
     @property
-    def txn_hash(self) -> HexBytes:
+    def txn_hash(self) -> "HexBytes":
         raise APINotImplementedError("Unable to calculate the hash of system transactions.")
 
     def serialize_transaction(self) -> bytes:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,9 @@
 [flake8]
 max-line-length = 100
+ignore = E704,W503,PYD002,TC003,TC006
 exclude =
 	venv*
 	.eggs
 	docs
 	build
+type-checking-pydantic-enabled = True

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,14 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=24.4.2,<25",  # Auto-formatter and linter
-        "mypy>=1.10.0,<2",  # Static type analyzer
+        "black>=24.10.0,<25",  # Auto-formatter and linter
+        "mypy>=1.13.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
-        "flake8>=7.0.0,<8",  # Style linter
+        "flake8>=7.1.1,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
         "isort>=5.13.2,<6",  # Import sorting linter
-        "mdformat>=0.7.17",  # Auto-formatter for markdown
+        "mdformat>=0.7.18",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
         "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml


### PR DESCRIPTION
### What I did

before:

```
In [1]: %time import ape_optimism
exitCPU times: user 1.75 s, sys: 175 ms, total: 1.92 s
Wall time: 1.92 s
```

after:

```
In [1]: %time import ape_optimism
CPU times: user 8.04 ms, sys: 3.53 ms, total: 11.6 ms
Wall time: 10.7 ms
```

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
